### PR TITLE
Add support for empty object with no additional properties

### DIFF
--- a/src/core/astBuilder.ts
+++ b/src/core/astBuilder.ts
@@ -176,6 +176,16 @@ export function buildFreeFormObjectTypeLiteralNode(): ts.TypeNode {
     ]);
 }
 
+export function buildEmptyObjectTypeLiteralNode(): ts.TypeNode {
+    return ts.factory.createTypeLiteralNode([
+        buildIndexSignatureNode(
+            'key',
+            buildStringKeyword(),
+            buildNeverKeyword(),
+        ),
+    ]);
+}
+
 export function buildUnionTypeNode<T>(
     types: T[],
     builder: (t: T, index: number) => ts.TypeNode,

--- a/src/core/dtsGenerator.ts
+++ b/src/core/dtsGenerator.ts
@@ -701,6 +701,8 @@ export default class DtsGenerator {
             const elements = this.generateProperties(schema);
             if (elements.length > 0) {
                 return ast.buildTypeLiteralNode(elements);
+            } else if (schema.content.additionalProperties === false) {
+                return ast.buildEmptyObjectTypeLiteralNode();
             } else {
                 return ast.buildFreeFormObjectTypeLiteralNode();
             }

--- a/test/additional_properties_test.ts
+++ b/test/additional_properties_test.ts
@@ -1,0 +1,58 @@
+import assert from 'assert';
+import dtsgenerator from '../src/core';
+import { clearToDefault } from '../src/core/config';
+import { OpenApisV3 } from '../src/core/openApiV3';
+import { parseSchema, JsonSchema } from '../src/core/type';
+
+describe('additionalProperties', () => {
+    afterEach(() => {
+        clearToDefault();
+    });
+
+    it('in a oneOf false on object with no properties', async () => {
+        const schema: OpenApisV3.SchemaJson = {
+            openapi: '3.0.3',
+            info: {
+                title: 'Test',
+                version: '0.4.0',
+            },
+            paths: {},
+            components: {
+                schemas: {
+                    EmptyObject: {
+                        oneOf: [
+                            {
+                                type: 'object',
+                                additionalProperties: false,
+                                properties: {
+                                    foo: {
+                                        type: 'string',
+                                    },
+                                },
+                            },
+                            {
+                                type: 'object',
+                                additionalProperties: false,
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+
+        const result = await dtsgenerator({
+            contents: [parseSchema(schema as JsonSchema)],
+        });
+        const expected = `declare namespace Components {
+    namespace Schemas {
+        export type EmptyObject = {
+            foo?: string;
+        } | {
+            [key: string]: never;
+        };
+    }
+}
+`;
+        assert.strictEqual(result, expected, result);
+    });
+});

--- a/test/commandOptions_test.ts
+++ b/test/commandOptions_test.ts
@@ -15,7 +15,7 @@ describe('output command help test', () => {
             .outputHelp();
         assert.strictEqual(
             output,
-            `Usage: dtsgenerator [options] <file ... | file patterns using node-glob>
+            `Usage: @anttiviljami/dtsgenerator [options] <file ... | file patterns using node-glob>
 
 Options:
   -V, --version           output the version number

--- a/test/utils_test.ts
+++ b/test/utils_test.ts
@@ -15,7 +15,7 @@ describe('root utils test', () => {
             const stream = fs.createReadStream(__dirname + '/../package.json');
             const data = await readStream(stream);
             const json = JSON.parse(data);
-            assert.equal(json.name, 'dtsgenerator');
+            assert.equal(json.name, '@anttiviljami/dtsgenerator');
         });
     });
 


### PR DESCRIPTION
The new test case shows the behavior I'd like to fix, when using an empty object in a union type, the generated types are wrong:

```yaml
# OpenAPI schema:
components:
  schemas:
    Object:
      oneOf:
        - type: object
          properties:
            foo:
              type: string
            bar:
              type: string
        - type: object
          additionalProperties: false
```

```typescript
// Expected behavior
type Object = { foo: string, bar: string } | { [key: string]: never }

// Actual behavior
type Object = { foo: string, bar: string } | { [key: string]: any }
```

This causes problem down the line in application code because TS incorrectly infers conditionals like such:

```typescript
function(foo: Object) {
  if (object.foo) {
    object.bar // here is infered as `any` while it should be `string`
  }
}
```
