### PR TITLE
Fix mergeSchema on object/array merge

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -86,13 +86,22 @@ export function mergeSchema(a: any, b: any): boolean {
     }
     Object.keys(b as object).forEach((key: string) => {
         const value = b[key];
-        if (a[key] != null && typeof value !== typeof a[key]) {
+        if (
+            a[key] != null &&
+            (typeof value !== typeof (a[key] ?? {}) ||
+                Array.isArray(value) !== Array.isArray(a[key] ?? []))
+        ) {
             debug(`mergeSchema warning: type is mismatched, key=${key}`);
         }
-        if (Array.isArray(value)) {
+        if (Array.isArray(value) && Array.isArray(a[key] ?? [])) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             a[key] = (a[key] ?? []).concat(value);
-        } else if (value != null && typeof value === 'object') {
+        } else if (
+            value != null &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            !Array.isArray(a[key] ?? {})
+        ) {
             a[key] ??= {};
             mergeSchema(a[key], value);
         } else {

--- a/test/core/utils_test.ts
+++ b/test/core/utils_test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { checkValidMIMEType } from '../../src/core/utils';
+import { checkValidMIMEType, mergeSchema } from '../../src/core/utils';
 
 describe('checkValidMIMEType test', () => {
     it('MIME type is plain text', () => {
@@ -85,5 +85,31 @@ describe('checkValidMIMEType test', () => {
         const mime = 'application/vnd.apple.pkpass';
         const actual = checkValidMIMEType(mime);
         assert.equal(actual, true, mime);
+    });
+});
+
+describe('mergeSchema test', () => {
+    it('mergeSchema object and array values', () => {
+        const a = { a: { b: 'nop' } };
+        const b = { a: [] };
+        const actual = mergeSchema(a, b);
+        assert.strictEqual(actual, true);
+        assert.deepEqual(a, { a: [] });
+    });
+
+    it('mergeSchema array values', () => {
+        const a = { a: ['1'] };
+        const b = { a: ['2'] };
+        const actual = mergeSchema(a, b);
+        assert.strictEqual(actual, true);
+        assert.deepEqual(a, { a: ['1', '2'] });
+    });
+
+    it('mergeSchema object values', () => {
+        const a = { a: { a: '1' } };
+        const b = { a: { b: '2' } };
+        const actual = mergeSchema(a, b);
+        assert.strictEqual(actual, true);
+        assert.deepEqual(a, { a: { a: '1', b: '2' } });
     });
 });


### PR DESCRIPTION
Some of my schema area either object or arrays and that mergeSchema function throw an error 

```
TypeError: (intermediate value)(intermediate value)(intermediate value).concat is not a function
```

Add some simple tests and check `a` and `b` are same type more safely.

`typeof value === 'object'` does not ensure that value is an object or an array.
This is because `typeof null === 'object'` and `typeof [] === 'object'`.
This commit fixes this by checking if value is an array using `Array.isArray(value)` instead of/with `typeof value === 'object'`.