### PR TITLE
fix: negative number

### DIFF
--- a/src/core/astBuilder.ts
+++ b/src/core/astBuilder.ts
@@ -48,6 +48,15 @@ export function buildStringLiteralTypeNode(s: string): ts.LiteralTypeNode {
     return ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(s));
 }
 export function buildNumericLiteralTypeNode(n: string): ts.LiteralTypeNode {
+    if (!isNaN(parseFloat(n)) && parseFloat(n) < 0) {
+        return ts.factory.createLiteralTypeNode(
+            ts.factory.createPrefixUnaryExpression(
+                ts.SyntaxKind.MinusToken,
+                ts.factory.createNumericLiteral(Math.abs(parseFloat(n))),
+            ),
+        );
+    }
+
     return ts.factory.createLiteralTypeNode(ts.factory.createNumericLiteral(n));
 }
 export function buildBooleanLiteralTypeNode(b: boolean): ts.LiteralTypeNode {

--- a/test/simple_schema_test.ts
+++ b/test/simple_schema_test.ts
@@ -254,6 +254,31 @@ describe('simple schema test', () => {
 `;
         assert.strictEqual(result, expected, result);
     });
+    it('positive and negative number type enum schema', async () => {
+        const schema: JsonSchemaDraft04.Schema = {
+            id: '/test/positive_negative_number_type',
+            type: 'object',
+            properties: {
+                numbers: {
+                    enum: [1, -1],
+                    example: '1',
+                },
+            },
+        };
+        const result = await dtsgenerator({ contents: [parseSchema(schema)] });
+
+        const expected = `declare namespace Test {
+    export interface PositiveNegativeNumberType {
+        /**
+         * example:
+         * 1
+         */
+        numbers?: 1 | -1;
+    }
+}
+`;
+        assert.strictEqual(result, expected, result);
+    });
     it('include const schema', async () => {
         const schema: JsonSchemaDraft07.Schema = {
             $id: '/test/include_const',


### PR DESCRIPTION
On our project we wanted to migrate to Typescript 5.4 but we encountered the following issue 

```
Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression
    at Object.createNumericLiteral (node_modules/typescript/lib/typescript.js:21097:13)
    at Object.buildNumericLiteralTypeNode (node_modules/@anttiviljami/dtsgenerator/dist/core/astBuilder.js:56:56)
    at DtsGenerator.generateLiteralTypeNode (node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:312:28)
    at node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:279:29
    at Array.map (<anonymous>)
    at Object.buildUnionTypeNode (node_modules/@anttiviljami/dtsgenerator/dist/core/astBuilder.js:124:55)
    at DtsGenerator.generateLiteralTypeProperty (node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:278:24)
    at DtsGenerator.generateTypeProperty (node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:273:21)
    at DtsGenerator.generateProperties (node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:244:84)
    at DtsGenerator.generateDeclareType (node_modules/@anttiviljami/dtsgenerator/dist/core/dtsGenerator.js:218:34)
```

So here is a PR to fix it.
To do it, I've locally bumped the Typescript version used to 5.4.5, created the test case and fixed the issue to use the right method.
I didn't want to upgrade the Typescript version in your `package.json` as I didn't know if you want to run further tests to declare your package compatible. If you want me to do it, let me know and I'll push an extra commit


This is a backport of [my PR](https://github.com/horiuchi/dtsgenerator/pull/566) done on the original repository and already released